### PR TITLE
prevent scaling factor from being 0 when weights are integers.

### DIFF
--- a/lib/linefit.rb
+++ b/lib/linefit.rb
@@ -438,7 +438,7 @@ private
          puts "At least two weights must be nonzero!" unless @hush
          return FALSE
       end
-      factor = weights.length / sumw
+      factor = weights.length.to_f / sumw
       weights.collect! {|weight| weight * factor}
       @weight = weights
       return TRUE


### PR DESCRIPTION
Thanks for this gem—it's been very helpful to us!

I kept getting "Can't fit line when x values are all equal", and realized it was because all of my weights were integers. This is just a tiny tweak so that integer weights don't cause the scaling factor to be zero.
