### PR TITLE
Fix exception in verification message

### DIFF
--- a/lib/linefit.rb
+++ b/lib/linefit.rb
@@ -466,7 +466,7 @@ private
             return FALSE
          end
          if @x[i] !~ /^([+-]?)(?=\d|\.\d)\d*(\.\d*)?([Ee]([+-]?\d+))?$/
-            puts "Input x[#{i}] is not a number: #{x[i]}" unless @hush
+            puts "Input x[#{i}] is not a number: #{@x[i]}" unless @hush
             return FALSE
          end
          unless @y[i]
@@ -474,7 +474,7 @@ private
             return FALSE
          end
          if @y[i] !~ /^([+-]?)(?=\d|\.\d)\d*(\.\d*)?([Ee]([+-]?\d+))?$/
-            puts "Input y[#{i}] is not a number: #{y[i]}" unless @hush
+            puts "Input y[#{i}] is not a number: #{@y[i]}" unless @hush
             return FALSE
          end
       end


### PR DESCRIPTION
When calling `#setData` with a linefit with verification enabled, I could see this:
```
NameError: undefined local variable or method `x' for #<LineFit:0x0056030c09ebf0>
Did you mean?  @x
	from .../linefit-0.3.3/lib/linefit.rb:469:in `block in validData'
	from .../lib/linefit.rb:463:in `upto'
	from .../lib/linefit.rb:463:in `validData'
	from .../lib/linefit.rb:286:in `setData'
	from (irb):17
```

This PR should fix the bitrot.